### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @camargo @AaronPlave
+* @duranb @AaronPlave


### PR DESCRIPTION
Remove Chris and add Bryan as a codeowner, affects default reviewers for PRs.